### PR TITLE
Option to not print parameter values to console

### DIFF
--- a/parsac/job/program.py
+++ b/parsac/job/program.py
@@ -532,7 +532,7 @@ class Job(shared.Job2):
         for parameter in self.parameters:
             parameter.store()
 
-    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, verbose=False):
+    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, verbose=True):
         assert self.started
         
         if verbose:

--- a/parsac/job/program.py
+++ b/parsac/job/program.py
@@ -532,7 +532,7 @@ class Job(shared.Job2):
         for parameter in self.parameters:
             parameter.store()
 
-    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, verbose=True):
+    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, verbose=False):
         assert self.started
         
         if verbose:

--- a/parsac/job/program.py
+++ b/parsac/job/program.py
@@ -532,10 +532,10 @@ class Job(shared.Job2):
         for parameter in self.parameters:
             parameter.store()
 
-    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, print_verbose=True):
+    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, verbose=True):
         assert self.started
         
-        if print_verbose:
+        if verbose:
             print('Evaluating fitness with parameter set [%s].' % ','.join(['%.6g' % v for v in values]))
 
         # If required, check whether all parameters are within their respective range.

--- a/parsac/job/program.py
+++ b/parsac/job/program.py
@@ -532,10 +532,11 @@ class Job(shared.Job2):
         for parameter in self.parameters:
             parameter.store()
 
-    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False):
+    def evaluate2(self, values, extra_outputs=None, return_model_values=False, show_output=False, print_verbose=True):
         assert self.started
-
-        print('Evaluating fitness with parameter set [%s].' % ','.join(['%.6g' % v for v in values]))
+        
+        if print_verbose:
+            print('Evaluating fitness with parameter set [%s].' % ','.join(['%.6g' % v for v in values]))
 
         # If required, check whether all parameters are within their respective range.
         if self.checkparameterranges:


### PR DESCRIPTION
Include option not to print parameter values to console during model simulations.
This will fix errors caused by limited internal memory.
The option is currently only implemented in evaluate2 function. For user ease, this should be threaded to input in console.